### PR TITLE
chore: bump up Hono; support new error handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "hono": "^2.0.6",
+    "hono": "^2.2.5",
     "toucan-js": "^2.6.1"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,11 +48,9 @@ export const sentry = (options?: Options, callback?: (sentry: Toucan) => void): 
     c.set('sentry', sentry)
     if (callback) callback(sentry)
 
-    try {
-      await next()
-    } catch (error) {
-      sentry.captureException(error)
-      throw error
+    await next()
+    if (c.error) {
+      sentry.captureException(c.error)
     }
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -21,6 +21,8 @@ describe('Sentry middleware', () => {
 
   app.use('/sentry/*', sentry(undefined, callback))
   app.get('/sentry/foo', (c) => c.text('foo'))
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
   app.get('/sentry/bar', (c) => getSentry(c).log('bar') || c.text('bar'))
   app.get('/sentry/error', () => {
     throw new Error('a catastrophic error')

--- a/yarn.lock
+++ b/yarn.lock
@@ -2280,10 +2280,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hono@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-2.0.6.tgz#fa4b17905a6fb187114beef3eebce13f163de99b"
-  integrity sha512-HgtiYdmBm4gayQ/IEUNbzQgBlEQdoN57F8A8QmtlqqoCgNvFNZ7J7KKEHiZHm4sviZ0SndBhQMlvkjupW0J3rg==
+hono@^2.2.5:
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-2.2.5.tgz#c0258d796d1e48e2b83b76f915a24c14fdf4f289"
+  integrity sha512-qIOLwQYJrTGwSSLahXvQ60nJT+NhZqsf+zSvj3eitBPCxpb+bsA2cl4clJzo1WNB+3KdxAdfVmUzq2stzby3eg==
 
 html-escaper@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Bumped up Hono to version v2.2.5. And support new error handling: https://github.com/honojs/hono/pull/576